### PR TITLE
Fix candidates window position when display-line-numbers-mode is enabled

### DIFF
--- a/mozc-cand-posframe.el
+++ b/mozc-cand-posframe.el
@@ -143,9 +143,10 @@ CANDIDATES must be the candidates field in a response protobuf."
                              (= (mozc-protobuf-get candidate 'index) current-index))
                     (mozc-cand-posframe--make-item candidate)))
          (after-current (mapcar #'mozc-cand-posframe--make-item source))
-         (x-pixel-offset (- (car (window-text-pixel-size nil
-                                                         (overlay-start mozc-preedit-overlay)
-                                                         (overlay-end mozc-preedit-overlay)))))
+         (x-pixel-offset (+ (- (car (window-text-pixel-size nil
+                                                            (overlay-start mozc-preedit-overlay)
+                                                            (overlay-end mozc-preedit-overlay))))
+                            (line-number-display-width t)))
          (posframe-width (apply #'max (mapcar #'mozc-cand-posframe-candidate-width
                                               (append before-current
                                                       (when current


### PR DESCRIPTION
display-line-numbers-mode が有効のとき、候補ウィンドウの位置が奇妙です。

<img width="236" alt="スクリーンショット 2020-02-06 0 33 21" src="https://user-images.githubusercontent.com/13937915/73856234-7c7c0780-4878-11ea-9f1e-30d9d9c78322.png">

どうやら原因は、display-line-numbers-mode が有効のとき`window-text-pixel-size`関数がline-number分の幅を含めた幅を返すからのようです。
なので`(line-number-display-width t)`を使ってdisplay-line-numbers-mode が有効のときでも正しい位置に配置されるようにしました。